### PR TITLE
Don't crash when tapping a device's hardware menu button

### DIFF
--- a/app/src/main/java/com/alorma/github/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/alorma/github/ui/activity/MainActivity.java
@@ -306,12 +306,16 @@ public class MainActivity extends BaseActivity implements OnMenuItemSelectedList
         return new GithubIconDrawable(this, icon).color(iconColor);
     }
 
+    private boolean hasInflated = false;
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
 
         if (getToolbar() != null) {
-            getToolbar().inflateMenu(R.menu.main_menu);
+            if (!hasInflated) {
+                getToolbar().inflateMenu(R.menu.main_menu);
+                hasInflated = true;
+            }
 
             MenuItem notificationsItem = menu.findItem(R.id.action_notifications);
 
@@ -319,10 +323,8 @@ public class MainActivity extends BaseActivity implements OnMenuItemSelectedList
 
             if (notificationProvider != null) {
                 notificationProvider.setOnNotificationListener(this);
+                bus.register(notificationProvider);
             }
-
-            bus.register(notificationProvider);
-
         }
 
         return true;


### PR DESCRIPTION
In reference to #92 and #58, `onCreateOptionsMenu` in `MainActivity` has been updated:

 - Don't duplicate the notifications / search icons when tapping on the menu button (the purpose of the `hasInflated` tag is to prevent multiple creations)
 - Only register the notificationProvider if it isn't null (root cause of crashing on some devices, including mine :grinning:)

If there is a cleaner way to implement this fix, feel free to let me know!